### PR TITLE
(entities) pull configuration from const

### DIFF
--- a/custom_components/nintendo_parental/__init__.py
+++ b/custom_components/nintendo_parental/__init__.py
@@ -1,8 +1,4 @@
-"""Custom integration to integrate integration_blueprint with Home Assistant.
-
-For more details about this integration, please refer to
-https://github.com/ludeeus/integration_blueprint
-"""
+"""Custom integration to integrate nintendo_parental with Home Assistant."""
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
@@ -12,16 +8,15 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .coordinator import NintendoUpdateCoordinator, Authenticator
 
-PLATFORMS: list[Platform] = [
-    Platform.SENSOR,
-    Platform.SWITCH
-]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
     hass.data.setdefault(DOMAIN, {})
-    nintendo_auth = await Authenticator.complete_login(None, entry.data["session_token"], True)
+    nintendo_auth = await Authenticator.complete_login(
+        None, entry.data["session_token"], True
+    )
     update_interval = entry.data["update_interval"]
     if entry.options:
         update_interval = entry.options.get("update_interval")
@@ -34,6 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     return True
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""

--- a/custom_components/nintendo_parental/config_flow.py
+++ b/custom_components/nintendo_parental/config_flow.py
@@ -1,5 +1,5 @@
 # pylint: disable=unused-argument
-"""Adds config flow for Blueprint."""
+"""Adds config flow for nintendo_parental."""
 from __future__ import annotations
 from typing import Any
 
@@ -27,7 +27,7 @@ from .const import (
 
 
 class BlueprintFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
-    """Config flow for Blueprint."""
+    """Config flow for nintendo_parental."""
 
     VERSION = 1
     auth = None

--- a/custom_components/nintendo_parental/const.py
+++ b/custom_components/nintendo_parental/const.py
@@ -2,6 +2,8 @@
 """Constants for integration_blueprint."""
 from logging import Logger, getLogger
 
+from homeassistant.components.sensor import SensorDeviceClass
+
 LOGGER: Logger = getLogger(__package__)
 
 NAME = "Nintendo Switch Parental Controls"
@@ -29,4 +31,15 @@ SW_CONFIGURATION_ENTITIES = {
         "name": "Block Device Access",
         "value": "limit_time",
     },
+}
+
+SENSOR_CONFIGURATION_ENTITIES = {
+    "screentime": {
+        "icon": None,
+        "name": "Used Screen Time",
+        "native_value": "playing_time",
+        "device_class": SensorDeviceClass.DURATION,
+        "native_unit_of_measurement": "min",
+        "state_attributes": "daily_summaries",
+    }
 }

--- a/custom_components/nintendo_parental/const.py
+++ b/custom_components/nintendo_parental/const.py
@@ -24,5 +24,10 @@ SW_CONFIGURATION_ENTITIES = {
         "icon": "mdi:block-helper",
         "name": "Suspend Software Limit",
         "value": "parental_control_settings",
-    }
+    },
+    "override": {
+        "icon": "mdi:block-helper",
+        "name": "Block Device Access",
+        "value": "limit_time",
+    },
 }

--- a/custom_components/nintendo_parental/const.py
+++ b/custom_components/nintendo_parental/const.py
@@ -1,5 +1,5 @@
 # pylint: disable=line-too-long
-"""Constants for integration_blueprint."""
+"""Constants for nintendo_parental."""
 from logging import Logger, getLogger
 
 from homeassistant.components.sensor import SensorDeviceClass

--- a/custom_components/nintendo_parental/const.py
+++ b/custom_components/nintendo_parental/const.py
@@ -6,7 +6,6 @@ LOGGER: Logger = getLogger(__package__)
 
 NAME = "Nintendo Switch Parental Controls"
 DOMAIN = "nintendo_parental"
-VERSION = "0.0.4"
 
 MIDDLEWARE_URL = (
     "{HASS}/auth/nintendo?return_url={RETURN}&nav_url={NAV}&title={TITLE}&info={INFO}"

--- a/custom_components/nintendo_parental/coordinator.py
+++ b/custom_components/nintendo_parental/coordinator.py
@@ -1,4 +1,4 @@
-"""DataUpdateCoordinator for integration_blueprint."""
+"""DataUpdateCoordinator for nintendo_parental."""
 from __future__ import annotations
 
 from datetime import timedelta
@@ -23,10 +23,7 @@ class NintendoUpdateCoordinator(DataUpdateCoordinator):
     config_entry: ConfigEntry
 
     def __init__(
-        self,
-        hass: HomeAssistant,
-        update_interval: int,
-        authenticator: Authenticator
+        self, hass: HomeAssistant, update_interval: int, authenticator: Authenticator
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -39,7 +36,8 @@ class NintendoUpdateCoordinator(DataUpdateCoordinator):
         self.api: NintendoParental = NintendoParental(
             auth=authenticator,
             timezone=hass.config.time_zone,
-            lang=hass.config.language)
+            lang=hass.config.language,
+        )
 
     async def _async_update_data(self):
         """Request the API to update."""

--- a/custom_components/nintendo_parental/entity.py
+++ b/custom_components/nintendo_parental/entity.py
@@ -1,4 +1,4 @@
-"""BlueprintEntity class."""
+"""nintendo_parental entity class."""
 from __future__ import annotations
 
 from homeassistant.helpers.entity import DeviceInfo
@@ -12,10 +12,9 @@ from .coordinator import NintendoUpdateCoordinator
 class NintendoDevice(CoordinatorEntity):
     """A Nintendo device."""
 
-    def __init__(self,
-                 coordinator: NintendoUpdateCoordinator,
-                 device_id,
-                 entity_id) -> None:
+    def __init__(
+        self, coordinator: NintendoUpdateCoordinator, device_id, entity_id
+    ) -> None:
         """Initialize."""
         super().__init__(coordinator)
         self.coordinator: NintendoUpdateCoordinator = coordinator
@@ -25,7 +24,9 @@ class NintendoDevice(CoordinatorEntity):
     @property
     def _device(self):
         """Return the device."""
-        return [x for x in self.coordinator.api.devices if x.device_id == self._device_id][0]
+        return [
+            x for x in self.coordinator.api.devices if x.device_id == self._device_id
+        ][0]
 
     @property
     def unique_id(self) -> str | None:
@@ -40,5 +41,7 @@ class NintendoDevice(CoordinatorEntity):
             manufacturer="Nintendo",
             name=self._device.name,
             entry_type=dr.DeviceEntryType.SERVICE,
-            sw_version=self._device.extra["device"]["firmwareVersion"]["displayedVersion"]
+            sw_version=self._device.extra["device"]["firmwareVersion"][
+                "displayedVersion"
+            ],
         )

--- a/custom_components/nintendo_parental/manifest.json
+++ b/custom_components/nintendo_parental/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
     "pynintendoparental==0.1.2"
   ],
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/custom_components/nintendo_parental/sensor.py
+++ b/custom_components/nintendo_parental/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform for integration_blueprint."""
+"""Sensor platform for nintendo_parental."""
 from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any

--- a/custom_components/nintendo_parental/sensor.py
+++ b/custom_components/nintendo_parental/sensor.py
@@ -6,7 +6,7 @@ from typing import Any
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass
 
-from .const import DOMAIN
+from .const import DOMAIN, SENSOR_CONFIGURATION_ENTITIES
 from .coordinator import NintendoUpdateCoordinator
 from .entity import NintendoDevice
 
@@ -16,45 +16,49 @@ async def async_setup_entry(hass, entry, async_add_devices):
     coordinator: NintendoUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities = []
     for device in coordinator.api.devices:
-        entities.append(
-            NintendoDeviceSensor(coordinator, device.device_id)
-        )
+        for sensor in SENSOR_CONFIGURATION_ENTITIES:
+            entities.append(NintendoDeviceSensor(coordinator, device.device_id, sensor))
     async_add_devices(entities, True)
+
 
 class NintendoDeviceSensor(NintendoDevice, SensorEntity):
     """nintendo_parental Sensor class."""
 
-    def __init__(
-        self,
-        coordinator,
-        device_id
-    ) -> None:
+    def __init__(self, coordinator, device_id, sensor) -> None:
         """Initialize the sensor class."""
-        super().__init__(coordinator, device_id, "screentime")
-        self._attr_should_poll = True # allow native value to be polled.
+        super().__init__(coordinator, device_id, sensor)
+        self._config = SENSOR_CONFIGURATION_ENTITIES.get(sensor)
+        self._attr_should_poll = True  # allow native value to be polled.
 
     @property
     def native_value(self) -> float:
         """Return the native value of the sensor."""
-        return self._device.daily_summaries[0].get("playingTime", 0) / 60
+        if self._config.get("native_value") == "playing_time":
+            return self._device.daily_summaries[0].get("playingTime", 0) / 60
 
     @property
     def native_unit_of_measurement(self) -> str:
         """Return unit of measurement."""
-        return "min"
+        return self._config.get("native_unit_of_measurement")
 
     @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return device class."""
-        return SensorDeviceClass.DURATION
+        return self._config.get("device_class")
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return extra state attributes."""
         # limited to 5 days to prevent HA recorder issues
-        return {"daily": self._device.daily_summaries[0:5]}
+        if self._config.get("state_attributes") == "daily_summaries":
+            return {"daily": self._device.daily_summaries[0:5]}
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon."""
+        return self._config.get("icon")
 
     @property
     def name(self) -> str | None:
         """Return entity name."""
-        return "Used Screen Time"
+        return self._config.get("name")

--- a/custom_components/nintendo_parental/switch.py
+++ b/custom_components/nintendo_parental/switch.py
@@ -2,7 +2,6 @@
 """Nintendo Switch Parental Controls switch platform."""
 
 import logging
-from typing import Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
 from homeassistant.config_entries import ConfigEntry
@@ -13,91 +12,39 @@ from pynintendoparental.enum import RestrictionMode
 
 from .coordinator import NintendoUpdateCoordinator
 
-from .const import (
-    DOMAIN,
-    SW_OVERRIDE_LIMIT_INVALID,
-    SW_CONFIGURATION_ENTITIES
-)
+from .const import DOMAIN, SW_OVERRIDE_LIMIT_INVALID, SW_CONFIGURATION_ENTITIES
 
 from .entity import NintendoDevice
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_entry(
-        hass: HomeAssistant,
-        entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Nintendo Switch Parental Control switches."""
     coordinator: NintendoUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities = []
     for device in coordinator.api.devices:
-        entities.append(
-            DeviceOverrideSwitch(coordinator, device.device_id)
-        )
         for config in SW_CONFIGURATION_ENTITIES:
             entities.append(
                 DeviceConfigurationSwitch(coordinator, device.device_id, config)
             )
     async_add_entities(entities, True)
 
-class DeviceOverrideSwitch(NintendoDevice, SwitchEntity):
-    """Defines a switch that can enable or disable a device."""
-
-    def __init__(
-        self,
-        coordinator,
-        device_id
-    ) -> None:
-        """Initialize the sensor class."""
-        super().__init__(coordinator, device_id, "override")
-        self._old_state = self._device.limit_time
-
-    @property
-    def name(self) -> str:
-        """Return entity name."""
-        return "Block Device Access"
-
-    @property
-    def is_on(self) -> bool:
-        """Return entity state."""
-        return self._device.limit_time == 0
-
-    @property
-    def device_class(self) -> SwitchDeviceClass | None:
-        """Return device class."""
-        return SwitchDeviceClass.SWITCH
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn on."""
-        self._old_state = self._device.limit_time
-        await self._device.update_max_daily_playtime(0)
-        return await self.coordinator.async_request_refresh()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn off."""
-        if self._old_state == 0:
-            _LOGGER.warning(SW_OVERRIDE_LIMIT_INVALID)
-            # defaulting to 180 minutes
-            await self._device.update_max_daily_playtime(180)
-        else:
-            await self._device.update_max_daily_playtime(self._old_state)
-        return await self.coordinator.async_request_refresh()
 
 class DeviceConfigurationSwitch(NintendoDevice, SwitchEntity):
     """A configuration switch."""
 
-    def __init__(
-        self,
-        coordinator,
-        device_id,
-        config_item
-    ) -> None:
+    def __init__(self, coordinator, device_id, config_item) -> None:
         """Initialize the sensor class."""
         super().__init__(coordinator, device_id, config_item)
         self._config = SW_CONFIGURATION_ENTITIES.get(config_item)
         self._config_item = config_item
         self._attr_should_poll = True
+        self._old_state = None
+        if self._config_item == "limit_time":
+            self._old_state = self._device.limit_time
 
     @property
     def name(self) -> str:
@@ -118,14 +65,33 @@ class DeviceConfigurationSwitch(NintendoDevice, SwitchEntity):
     def is_on(self) -> bool | None:
         """Return entity state."""
         if self._config_item == "restriction_mode":
-            return self._device.parental_control_settings["playTimerRegulations"]["restrictionMode"] == "FORCED_TERMINATION"
+            return (
+                self._device.parental_control_settings["playTimerRegulations"][
+                    "restrictionMode"
+                ]
+                == "FORCED_TERMINATION"
+            )
+        if self._config_item == "limit_time":
+            return self._device.limit_time == 0
 
     async def async_turn_on(self, **kwargs) -> None:
         """Enable forced termination mode."""
-        await self._device.set_restriction_mode(RestrictionMode.FORCED_TERMINATION)
+        if self._config_item == "restriction_mode":
+            await self._device.set_restriction_mode(RestrictionMode.FORCED_TERMINATION)
+        if self._config_item == "limit_time":
+            self._old_state = self._device.limit_time
+            await self._device.update_max_daily_playtime(0)
         return await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Enable alarm mode."""
-        await self._device.set_restriction_mode(RestrictionMode.ALARM)
+        if self._config_item == "restriction_mode":
+            await self._device.set_restriction_mode(RestrictionMode.ALARM)
+        if self._config_item == "limit_time":
+            if self._old_state == 0:
+                _LOGGER.warning(SW_OVERRIDE_LIMIT_INVALID)
+                # defaulting to 180 minutes
+                await self._device.update_max_daily_playtime(180)
+            else:
+                await self._device.update_max_daily_playtime(self._old_state)
         return await self.coordinator.async_request_refresh()


### PR DESCRIPTION
Configuration for entities is now pulled from `const.py` rather than duplicating code.