### PR TITLE
Add support for whitelist control

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ _Integration to integrate with [ha-nintendoparentalcontrols][ha-nintendoparental
 1. The configuration flow should then show some additional options, don't adjust the first box as this is the session token that will be used to refresh the tokens in the background
 1. Click `Submit`
 
-## Home Assistant Repairs
+<!-- ## Home Assistant Repairs
 
-<!-- In version 2023.11.0 support for HA repairs was introduced as a way to inform you of errors relating to your configuration, the repairs will go away themselves once the error is resolved.
+In version 2023.11.0 support for HA repairs was introduced as a way to inform you of errors relating to your configuration, the repairs will go away themselves once the error is resolved.
 
 Currently two repair types are created, one for OAuth issues, and another for device sync issues.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Integration to integrate with [ha-nintendoparentalcontrols][ha-nintendoparental
 | Platform | Description                                    |
 | -------- | ---------------------------------------------- |
 | `sensor` | Read only states (such as current screen time) |
-| `switch` | Basic device controls.                            |
+| `switch` | Per app and device controls                    |
 
 ## Supported features
 
@@ -21,8 +21,10 @@ _Integration to integrate with [ha-nintendoparentalcontrols][ha-nintendoparental
 - Screen time sensor displays last 5 days of usage, including applications used and players.
 - Switch to enable/disable the "Suspend Software" mode once the screentime limit has been reached.
 - Switch to enable and disable alarms for the current day, Nintendo resets this back at midnight.
-- Raises issues if an error occures with the OAuth configuration (such as Nintendo changing the client IDs).
-- Raises a configflow to handle reauthentication if the session token expires (usually around 2 years).
+- Time platform to adjust the total amount of time allowed to play in the day, setting this to 0:00 and turning on "Suspend Software Limit" will effectively disable the device unless you enter the parental controls pin
+- Optional switches to control the whitelist state of applications, this needs to be configured from the options menu.
+<!-- - Raises issues if an error occures with the OAuth configuration (such as Nintendo changing the client IDs).
+- Raises a configflow to handle reauthentication if the session token expires (usually around 2 years). -->
 
 ## Installation
 
@@ -55,9 +57,9 @@ If you see this error, you should verify your parental controls configuration in
 | Suspend Software | Enabled or Disabled |
 | Set Days Individually | Off | -->
 
-### Mobile application has been updated
+<!-- ### Mobile application has been updated
 
-This happens if Nintendo has updated the mobile app significantly and the OAuth tokens that are hardcoded into pynintendoparental are out of date. If this happens please log an issue.
+This happens if Nintendo has updated the mobile app significantly and the OAuth tokens that are hardcoded into pynintendoparental are out of date. If this happens please log an issue. -->
 
 ## Middleware notes
 

--- a/custom_components/nintendo_parental/__init__.py
+++ b/custom_components/nintendo_parental/__init__.py
@@ -1,19 +1,17 @@
 """Custom integration to integrate nintendo_parental with Home Assistant."""
 from __future__ import annotations
-import contextlib
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryError
-from homeassistant.helpers import issue_registry as ir
 
 from pynintendoparental.exceptions import (
     InvalidSessionTokenException,
     InvalidOAuthConfigurationException,
 )
 
-from .const import DOMAIN, ISSUE_DEPENDANCY_ID, ISSUE_DEPENDANCY_KEY, GH_REPO_URL
+from .const import DOMAIN
 from .coordinator import NintendoUpdateCoordinator, Authenticator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH, Platform.TIME]
@@ -29,24 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except InvalidSessionTokenException as err:
         raise ConfigEntryAuthFailed(err) from err
     except InvalidOAuthConfigurationException as err:
-        ir.create_issue(
-            hass,
-            DOMAIN,
-            issue_id=ISSUE_DEPENDANCY_ID,
-            is_fixable=False,
-            severity=ir.IssueSeverity.ERROR,
-            translation_key=ISSUE_DEPENDANCY_KEY,
-            learn_more_url=GH_REPO_URL,
-        )
         raise ConfigEntryError(err) from err
-
-    with contextlib.suppress(TypeError):
-        # check if an issue exists for ISSUE_DEPENDANCY_ID
-        issue = await ir.async_get(hass).async_get_issue(
-            domain=DOMAIN, issue_id=ISSUE_DEPENDANCY_ID
-        )
-        if issue is not None:
-            await ir.async_delete_issue(hass, DOMAIN, ISSUE_DEPENDANCY_ID)
 
     coord = NintendoUpdateCoordinator(hass, nintendo_auth, entry)
     # request first data sync

--- a/custom_components/nintendo_parental/__init__.py
+++ b/custom_components/nintendo_parental/__init__.py
@@ -11,7 +11,7 @@ from pynintendoparental.exceptions import (
     InvalidOAuthConfigurationException,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, CONF_SESSION_TOKEN
 from .coordinator import NintendoUpdateCoordinator, Authenticator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH, Platform.TIME]
@@ -22,7 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     try:
         nintendo_auth = await Authenticator.complete_login(
-            None, entry.data["session_token"], True
+            None, entry.data[CONF_SESSION_TOKEN], True
         )
     except InvalidSessionTokenException as err:
         raise ConfigEntryAuthFailed(err) from err

--- a/custom_components/nintendo_parental/config_flow.py
+++ b/custom_components/nintendo_parental/config_flow.py
@@ -157,11 +157,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """Initialize options flow."""
         self.config_entry = config_entry
 
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> config_entries.FlowResult:
-        """First step."""
-
+    async def async_step_config(self, user_input: dict[str, Any] | None = None):
+        """Extra options flow."""
         if user_input is not None:
             return self.async_create_entry(
                 title=self.config_entry.title,
@@ -193,6 +190,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 }
             ),
         )
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """First step."""
 
 
 class MiddlewareServerView(HomeAssistantView):

--- a/custom_components/nintendo_parental/const.py
+++ b/custom_components/nintendo_parental/const.py
@@ -18,6 +18,12 @@ AUTH_MIDDLEWARE_PATH = "/auth/nintendo"
 AUTH_MIDDLEWARE_NAME = "auth:nintendo"
 AUTH_MIDDLEWARE_CONTENT = "{CWD}/custom_components/nintendo_parental/middleware.html"
 
+CONF_APPLICATIONS = "applications"
+CONF_SESSION_TOKEN = "session_token"
+CONF_UPDATE_INTERVAL = "update_interval"
+CONF_DEFAULT_MAX_PLAYTIME = "default_max_playtime"
+
+
 SW_CONFIGURATION_ENTITIES = {
     "restriction_mode": {
         "icon": "mdi:block-helper",
@@ -28,7 +34,7 @@ SW_CONFIGURATION_ENTITIES = {
         "icon": "mdi:block-helper",
         "name": "Block Device Access",
         "value": "limit_time",
-        "enabled": False
+        "enabled": False,
     },
     "alarms_enabled": {
         "icon": "mdi:alarm",

--- a/custom_components/nintendo_parental/coordinator.py
+++ b/custom_components/nintendo_parental/coordinator.py
@@ -20,7 +20,13 @@ from pynintendoparental.exceptions import (
     InvalidOAuthConfigurationException,
 )
 
-from .const import DOMAIN, LOGGER, DEFAULT_MAX_PLAYTIME
+from .const import (
+    DOMAIN,
+    LOGGER,
+    DEFAULT_MAX_PLAYTIME,
+    CONF_DEFAULT_MAX_PLAYTIME,
+    CONF_UPDATE_INTERVAL,
+)
 
 
 class NintendoUpdateCoordinator(DataUpdateCoordinator):
@@ -33,9 +39,9 @@ class NintendoUpdateCoordinator(DataUpdateCoordinator):
         config_entry: ConfigEntry,
     ) -> None:
         """Initialize."""
-        self._update_interval = config_entry.data["update_interval"]
+        self._update_interval = config_entry.data[CONF_UPDATE_INTERVAL]
         if config_entry.options:
-            self.update_interval = config_entry.options.get("update_interval")
+            self.update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL)
         super().__init__(
             hass=hass,
             logger=LOGGER,
@@ -50,11 +56,11 @@ class NintendoUpdateCoordinator(DataUpdateCoordinator):
         )
         self.config_entry: ConfigEntry = config_entry
         self.default_max_playtime = config_entry.data.get(
-            "default_max_playtime", DEFAULT_MAX_PLAYTIME
+            CONF_DEFAULT_MAX_PLAYTIME, DEFAULT_MAX_PLAYTIME
         )
         if config_entry.options:
             self.default_max_playtime = config_entry.options.get(
-                "default_max_playtime", DEFAULT_MAX_PLAYTIME
+                CONF_DEFAULT_MAX_PLAYTIME, DEFAULT_MAX_PLAYTIME
             )
 
     async def _async_update_data(self):

--- a/custom_components/nintendo_parental/manifest.json
+++ b/custom_components/nintendo_parental/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
     "pynintendoparental==0.2.0"
   ],
-  "version": "2023.12.0b0"
+  "version": "2023.12.0"
 }

--- a/custom_components/nintendo_parental/manifest.json
+++ b/custom_components/nintendo_parental/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
     "pynintendoparental==0.1.12"
   ],
-  "version": "2023.11.3"
+  "version": "2023.12.0b0"
 }

--- a/custom_components/nintendo_parental/manifest.json
+++ b/custom_components/nintendo_parental/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pantherale0/ha-nintendoparentalcontrols/issues",
   "requirements": [
-    "pynintendoparental==0.1.12"
+    "pynintendoparental==0.2.0"
   ],
   "version": "2023.12.0b0"
 }

--- a/custom_components/nintendo_parental/strings.json
+++ b/custom_components/nintendo_parental/strings.json
@@ -43,6 +43,15 @@
                     "default_max_playtime": "Default maximum play time (minutes)"
                 }
             },
+            "applications": {
+                "description": "Configure applications to register control entities for.",
+                "menu_options": {
+                    "applications_create": "Add new application",
+                    "applications_update": "Update existing application",
+                    "applications_delete": "Delete application",
+                    "done": "Return to main menu"
+                }
+            },
             "reauth": {
                 "description": "Reauthenticate with Nintendo Online service."
             },

--- a/custom_components/nintendo_parental/strings.json
+++ b/custom_components/nintendo_parental/strings.json
@@ -29,6 +29,14 @@
     "options": {
         "step": {
             "init": {
+                "title": "Nintendo Switch Parental Controls",
+                "menu_options": {
+                    "applications": "Configure applications to register entities",
+                    "config": "Extra options",
+                    "done": "Save and exit"
+                }
+            },
+            "config": {
                 "description": "Update Nintendo Switch Parental Controls configuration",
                 "data": {
                     "update_interval": "Update interval (seconds)",

--- a/custom_components/nintendo_parental/strings.json
+++ b/custom_components/nintendo_parental/strings.json
@@ -44,12 +44,9 @@
                 }
             },
             "applications": {
-                "description": "Configure applications to register control entities for.",
-                "menu_options": {
-                    "applications_create": "Add new application",
-                    "applications_update": "Update existing application",
-                    "applications_delete": "Delete application",
-                    "done": "Return to main menu"
+                "description": "Configure applications to register whitelist control entites for.",
+                "data": {
+                    "applications": "App name(s)"
                 }
             },
             "reauth": {

--- a/custom_components/nintendo_parental/translations/en.json
+++ b/custom_components/nintendo_parental/translations/en.json
@@ -44,12 +44,9 @@
                 }
             },
             "applications": {
-                "description": "Configure applications to register control entities for.",
-                "menu_options": {
-                    "applications_create": "Add new application",
-                    "applications_update": "Update existing application",
-                    "applications_delete": "Delete application",
-                    "done": "Return to main menu"
+                "description": "Configure applications to register whitelist control entites for.",
+                "data": {
+                    "applications": "App name(s)"
                 }
             },
             "reauth": {

--- a/custom_components/nintendo_parental/translations/en.json
+++ b/custom_components/nintendo_parental/translations/en.json
@@ -1,4 +1,14 @@
 {
+    "issues": {
+        "dependancy_needs_updating": {
+            "title": "Mobile application has been updated",
+            "description": "A change has occured to the OAuth authentication method used by the Nintendo Switch Parental Controls mobile app.\n\nThis issue is not resolvable, please use the learn more link to report this issue to the maintainer."
+        },
+        "configuration_error": {
+            "title": "Error setting up {name}",
+            "description": "There was a problem with the response from Nintendo for this device, check the logs for further information.\n\nThis can occur due to a config issue with the parental control settings.\n\nBefore reporting this issue, make sure that debug mode has been turned on and reload the integration."
+        }
+    },
     "config": {
         "step": {
             "configure": {
@@ -19,10 +29,27 @@
     "options": {
         "step": {
             "init": {
+                "title": "Nintendo Switch Parental Controls",
+                "menu_options": {
+                    "applications": "Configure applications to register entities",
+                    "config": "Extra options",
+                    "done": "Save and exit"
+                }
+            },
+            "config": {
                 "description": "Update Nintendo Switch Parental Controls configuration",
                 "data": {
                     "update_interval": "Update interval (seconds)",
                     "default_max_playtime": "Default maximum play time (minutes)"
+                }
+            },
+            "applications": {
+                "description": "Configure applications to register control entities for.",
+                "menu_options": {
+                    "applications_create": "Add new application",
+                    "applications_update": "Update existing application",
+                    "applications_delete": "Delete application",
+                    "done": "Return to main menu"
                 }
             },
             "reauth": {

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "Nintendo Switch Parental Controls",
     "filename": "nintendo_parental.zip",
     "hide_default_branch": true,
-    "homeassistant": "2023.7.0",
+    "homeassistant": "2023.12.0",
     "render_readme": true,
     "zip_release": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.7.0
-homeassistant==2023.7.3
+homeassistant==2023.12.0
 pip>=21.0,<23.4
 ruff==0.1.6
 pynintendoparental==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.7.0
 homeassistant==2023.12.0
 pip>=21.0,<23.4
 ruff==0.1.6
-pynintendoparental==0.1.12
+pynintendoparental==0.2.0


### PR DESCRIPTION
This PR introduces support for the Parental Controls whitelisted applications.

Per application switch entities will be created (if enabled and available on the Switch device).

Resilience has been built in to prevent the creation of application entities if they are not available for the device, however this is untested as I only have 1 device.

resolves #41 