### PR TITLE
Resolve error setting up switch platform

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,17 +13,17 @@ jobs:
     name: "Ruff"
     runs-on: "ubuntu-latest"
     steps:
-        - name: "Checkout the repository"
-          uses: "actions/checkout@v4.1.0"
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v4.1.0"
 
-        - name: "Set up Python"
-          uses: actions/setup-python@v5.0.0
-          with:
-            python-version: "3.10"
-            cache: "pip"
+      - name: "Set up Python"
+        uses: actions/setup-python@v5.0.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
 
-        - name: "Install requirements"
-          run: python3 -m pip install -r requirements.txt
+      - name: "Install requirements"
+        run: python3 -m pip install -r requirements.txt
 
-        - name: "Run"
-          run: python3 -m ruff check .
+      - name: "Run"
+        run: python3 -m ruff check .

--- a/custom_components/nintendo_parental/manifest.json
+++ b/custom_components/nintendo_parental/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
     "pynintendoparental==0.2.0"
   ],
-  "version": "2023.12.0"
+  "version": "2023.12.1"
 }

--- a/custom_components/nintendo_parental/switch.py
+++ b/custom_components/nintendo_parental/switch.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
                 entities.append(
                     DeviceConfigurationSwitch(coordinator, device.device_id, config)
                 )
-            for app_id in entry.options[CONF_APPLICATIONS]:
+            for app_id in entry.options.get(CONF_APPLICATIONS, []):
                 try:
                     entities.append(
                         ApplicationWhitelistSwitch(

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "Nintendo Switch Parental Controls",
     "filename": "nintendo_parental.zip",
     "hide_default_branch": true,
-    "homeassistant": "2023.12.0",
+    "homeassistant": "2023.12.4",
     "render_readme": true,
     "zip_release": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.8.0
-homeassistant==2023.12.0
+homeassistant==2023.12.4
 pip>=21.0,<23.4
 ruff==0.1.8
 pynintendoparental==0.2.0


### PR DESCRIPTION
Resolves the following error while setting up the switch platform if the integration has never been setup before:

`KeyError: 'applications'`