### PR TITLE
Assume state of whitelisted apps

### DIFF
--- a/custom_components/nintendo_parental/manifest.json
+++ b/custom_components/nintendo_parental/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
     "pynintendoparental==0.3.3"
   ],
-  "version": "2023.12.4"
+  "version": "2023.12.5"
 }

--- a/custom_components/nintendo_parental/switch.py
+++ b/custom_components/nintendo_parental/switch.py
@@ -54,13 +54,12 @@ async def async_setup_entry(
 class ApplicationWhitelistSwitch(NintendoDevice, SwitchEntity):
     """A configuration switch."""
 
+    _attr_should_poll = True
+
     def __init__(self, coordinator, device_id, app: Application) -> None:
         """Initialize the sensor class."""
         super().__init__(coordinator, device_id, app.application_id)
         self._app_id = app.application_id
-        self._assumed_state = (
-            self._device.whitelisted_applications.get(self._app_id, None) is None
-        )
 
     @property
     def _application(self) -> Application:
@@ -90,7 +89,7 @@ class ApplicationWhitelistSwitch(NintendoDevice, SwitchEntity):
     @property
     def assumed_state(self) -> bool:
         """Return true if unable to access whitelisted application."""
-        return self._assumed_state
+        return self._device.whitelisted_applications.get(self._app_id, None) is None
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable whitelisted mode."""

--- a/custom_components/nintendo_parental/switch.py
+++ b/custom_components/nintendo_parental/switch.py
@@ -58,6 +58,9 @@ class ApplicationWhitelistSwitch(NintendoDevice, SwitchEntity):
         """Initialize the sensor class."""
         super().__init__(coordinator, device_id, app.application_id)
         self._app_id = app.application_id
+        self._assumed_state = (
+            self._device.whitelisted_applications.get(self._app_id, None) is None
+        )
 
     @property
     def _application(self) -> Application:
@@ -82,7 +85,12 @@ class ApplicationWhitelistSwitch(NintendoDevice, SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         """Return entity state."""
-        return self._device.whitelisted_applications[self._app_id]
+        return self._device.whitelisted_applications.get(self._app_id, None)
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return true if unable to access whitelisted application."""
+        return self._assumed_state
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable whitelisted mode."""


### PR DESCRIPTION
#55

New Nintendo devices/accounts don't report enough information to load application data into the device currently, this patch will resolve this issue by telling Home Assistant to assume the state of the entity.