### PR TITLE
Added details for the access token copy method in the wizard

### DIFF
--- a/custom_components/nintendo_parental/strings.json
+++ b/custom_components/nintendo_parental/strings.json
@@ -21,7 +21,7 @@
                 }
             },
             "nintendo_website_auth": {
-                "description": "Click this link [Nintendo Login]({link}) to login to Nintendo and retrieve the access token for the next input.",
+                "description": "Click this link [Nintendo Login]({link}) to login to Nintendo. For the account you wish to link, right click on the red button Select this person and click Copy Link to use in the next step.",
                 "data": {
                     "api_token": "Access token"
                 }


### PR DESCRIPTION
README is clear, but the message in the wizard is not. This PR simply add details on what to do.