### PR TITLE
Add bonus time service to Nintendo Parental integration

### DIFF
--- a/custom_components/nintendo_parental/__init__.py
+++ b/custom_components/nintendo_parental/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_SESSION_TOKEN, DOMAIN
@@ -19,6 +20,8 @@ from .repairs import raise_invalid_auth
 from .services import async_setup_services
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH, Platform.TIME, Platform.NUMBER]
+
+PLATFORM_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Nintendo Switch Parental Controls integration."""

--- a/custom_components/nintendo_parental/__init__.py
+++ b/custom_components/nintendo_parental/__init__.py
@@ -11,13 +11,19 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_SESSION_TOKEN, DOMAIN
 from .coordinator import NintendoParentalConfigEntry, NintendoUpdateCoordinator
 from .repairs import raise_invalid_auth
+from .services import async_setup_services
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH, Platform.TIME, Platform.NUMBER]
 
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Nintendo Switch Parental Controls integration."""
+    async_setup_services(hass)
+    return True
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: NintendoParentalConfigEntry

--- a/custom_components/nintendo_parental/services.py
+++ b/custom_components/nintendo_parental/services.py
@@ -1,0 +1,73 @@
+"""Services for Nintendo Parental integration."""
+
+import logging
+
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+)
+
+import voluptuous as vol
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+@callback
+def async_setup_services(
+    hass: HomeAssistant,
+):
+    """Set up the Nintendo Parental services."""
+    hass.services.async_register(
+        domain=DOMAIN,
+        service="add_bonus_time",
+        service_func=async_add_bonus_time,
+        schema=vol.Schema({
+            vol.Required("integration_id"): cv.string,
+            vol.Required("device_id"): cv.string,
+            vol.Required("bonus_time"): int,
+        })
+    )
+
+def get_config_entry(hass: HomeAssistant, account_id: str):
+    """Get the coordinator from the Home Assistant instance."""
+    return hass.config_entries.async_get_entry(account_id)
+
+async def async_add_bonus_time(
+    call: ServiceCall
+) -> None:
+    """Add bonus time to a device."""
+    data = call.data
+    config_entry = get_config_entry(call.hass, data["integration_id"])
+    if config_entry is None:
+        raise HomeAssistantError(
+            f"Config entry for integration_id {data['integration_id']} not found"
+        )
+    device_id: str = data["device_id"]
+    bonus_time: int = data["bonus_time"]
+    if not device_id or not bonus_time:
+        raise ServiceValidationError(
+            "device_id and bonus_time are required fields"
+        )
+
+    if bonus_time < -1 or bonus_time > 1440:
+        raise ServiceValidationError(
+            "bonus_time must be between -1 and 1440 minutes"
+        )
+
+    device = dr.async_get(call.hass).async_get(device_id)
+    if device is None:
+        raise HomeAssistantError(f"Device with ID {device_id} not found")
+    device_id = next(iter(device.identifiers))[1].split("_")[-1]
+
+    coordinator = config_entry.runtime_data
+    if not coordinator:
+        raise HomeAssistantError("Coordinator is not available")
+
+    try:
+        await coordinator.api.devices[device_id].add_extra_time(bonus_time)
+    except Exception as e:
+        _LOGGER.error(f"Failed to add bonus time: {e}")
+        raise HomeAssistantError(f"Failed to add bonus time: {e}") from e

--- a/custom_components/nintendo_parental/services.py
+++ b/custom_components/nintendo_parental/services.py
@@ -27,7 +27,7 @@ def async_setup_services(
         schema=vol.Schema({
             vol.Required("integration_id"): cv.string,
             vol.Required("device_id"): cv.string,
-            vol.Required("bonus_time"): int,
+            vol.Required("bonus_time"): vol.All(int, vol.Range(min=-1, max=1440)),
         })
     )
 

--- a/custom_components/nintendo_parental/services.yaml
+++ b/custom_components/nintendo_parental/services.yaml
@@ -1,0 +1,23 @@
+add_bonus_time:
+  fields:
+    bonus_time:
+      required: true
+      example: 30
+      selector:
+        number:
+          min: -1
+          max: 1440
+          unit_of_measurement: minutes
+          mode: box
+    integration_id:
+      required: true
+      example: 1234567890abcdef1234567890abcdef
+      selector:
+        config_entry:
+          integration: nintendo_parental
+    device_id:
+      required: true
+      example: 1234567890abcdef1234567890abcdef
+      selector:
+        device:
+          integration: nintendo_parental

--- a/custom_components/nintendo_parental/strings.json
+++ b/custom_components/nintendo_parental/strings.json
@@ -45,5 +45,26 @@
       "description": "No devices were found for {account_id}. Please ensure that the account has a Nintendo Switch linked to it and that the parental controls are set up correctly.",
       "title": "No devices found"
     }
+  },
+  "services": {
+    "add_bonus_time": {
+      "description": "Add bonus screen time to the selected Nintendo Switch.",
+      "fields": {
+        "bonus_time": {
+          "description": "The amount of bonus time to add in minutes. Maximum is 1440 minutes, minimum is -1. Use -1 for no further time limit.",
+          "example": 30,
+          "name": "Bonus Time"
+        },
+        "device_id": {
+          "description": "The ID of the device to add bonus time to.",
+          "example": "1234567890abcdef",
+          "name": "Device"
+        },
+        "integration_id": {
+          "name": "Account"
+        }
+      },
+      "name": "Add Bonus Time"
+    }
   }
 }

--- a/custom_components/nintendo_parental/strings.json
+++ b/custom_components/nintendo_parental/strings.json
@@ -61,6 +61,7 @@
           "name": "Device"
         },
         "integration_id": {
+          "description": "The ID of the account to which the device belongs.",
           "name": "Account"
         }
       },

--- a/custom_components/nintendo_parental/strings.json
+++ b/custom_components/nintendo_parental/strings.json
@@ -52,7 +52,6 @@
       "fields": {
         "bonus_time": {
           "description": "The amount of bonus time to add in minutes. Maximum is 1440 minutes, minimum is -1. Use -1 for no further time limit.",
-          "example": 30,
           "name": "Bonus Time"
         },
         "device_id": {

--- a/custom_components/nintendo_parental/translations/en.json
+++ b/custom_components/nintendo_parental/translations/en.json
@@ -38,12 +38,33 @@
       "title": "Mobile application has been updated"
     },
     "invalid_auth": {
-      "description": "The stored authentication token is invalid. Please reconfigure the integration.",
+      "description": "The stored authentication token for {account_id} is invalid. Please reconfigure the integration.",
       "title": "Invalid authentication"
     },
     "no_devices_found": {
-      "description": "No devices were found for this account. Please ensure that the account has a Nintendo Switch linked to it and that the parental controls are set up correctly.",
+      "description": "No devices were found for {account_id}. Please ensure that the account has a Nintendo Switch linked to it and that the parental controls are set up correctly.",
       "title": "No devices found"
+    }
+  },
+  "services": {
+    "add_bonus_time": {
+      "description": "Add bonus screen time to the selected Nintendo Switch.",
+      "fields": {
+        "bonus_time": {
+          "description": "The amount of bonus time to add in minutes. Maximum is 1440 minutes, minimum is -1. Use -1 for no further time limit.",
+          "example": 30,
+          "name": "Bonus Time"
+        },
+        "device_id": {
+          "description": "The ID of the device to add bonus time to.",
+          "example": "1234567890abcdef",
+          "name": "Device"
+        },
+        "integration_id": {
+          "name": "Account"
+        }
+      },
+      "name": "Add Bonus Time"
     }
   }
 }

--- a/custom_components/nintendo_parental/translations/en.json
+++ b/custom_components/nintendo_parental/translations/en.json
@@ -61,6 +61,7 @@
           "name": "Device"
         },
         "integration_id": {
+          "description": "The ID of the account to which the device belongs.",
           "name": "Account"
         }
       },

--- a/custom_components/nintendo_parental/translations/en.json
+++ b/custom_components/nintendo_parental/translations/en.json
@@ -52,7 +52,6 @@
       "fields": {
         "bonus_time": {
           "description": "The amount of bonus time to add in minutes. Maximum is 1440 minutes, minimum is -1. Use -1 for no further time limit.",
-          "example": 30,
           "name": "Bonus Time"
         },
         "device_id": {


### PR DESCRIPTION
Introduce a new service to add bonus screen time for devices in the Nintendo Parental Controls integration, along with necessary setup and validation.