### PR TITLE
Fix GitHub repository link in documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,4 +14,4 @@ To get started, your Switch will already need to be paired with the Nintendo Swi
 
 ## Support
 
-If you encounter any issues or have questions, please open an issue on the [GitHub repository](https://github.com/pantheraleo/ha-nintendoparentalcontrols).
+If you encounter any issues or have questions, please open an issue on the [GitHub repository](https://github.com/pantherale0/ha-nintendoparentalcontrols).


### PR DESCRIPTION
Correct the URL for the GitHub repository in the documentation to ensure users access the right location for support.